### PR TITLE
fix/#10 왼쪽/위 방향 드래그 드롭 시 transform transition 제거

### DIFF
--- a/src/components/FolderIcon/main/FolderIcon.module.css
+++ b/src/components/FolderIcon/main/FolderIcon.module.css
@@ -9,11 +9,10 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: box-shadow 0.2s ease;
 }
 
 .appIcon:hover {
-  transform: scale(1.05);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
## Summary

- FolderIcon.module.css에서 왼쪽/위 방향 드래그 드롭 시 발생하는 transform transition 제거
- 드롭 후 아이콘이 이전 위치로 슬라이드되는 시각적 버그 수정

## Test plan

- [ ] 아이콘을 왼쪽 방향으로 드래그 후 드롭 — transition 없이 즉시 배치되는지 확인
- [ ] 아이콘을 위쪽 방향으로 드래그 후 드롭 — transition 없이 즉시 배치되는지 확인
- [ ] 오른쪽/아래쪽 방향 드래그도 기존과 동일하게 동작하는지 확인

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)