### PR TITLE
feat/#15 Galaxy One UI 폴더 기능 구현

### DIFF
--- a/src/components/Desktop/main/Desktop.js
+++ b/src/components/Desktop/main/Desktop.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef } from "react";
 import { DndContext, DragOverlay, PointerSensor, rectIntersection, useSensor, useSensors, defaultDropAnimationSideEffects } from "@dnd-kit/core";
 import { SortableContext, arrayMove } from "@dnd-kit/sortable";
-import AppIcon, { EmptySlot, AppIconOverlay } from "../../FolderIcon/main/FolderIcon";
+import AppIcon, { EmptySlot, AppIconOverlay, FolderIcon, FolderIconOverlay } from "../../FolderIcon/main/FolderIcon";
 import PageDropZone from "../../PageDropZone/main/PageDropZone";
+import FolderModal from "../../FolderModal/main/FolderModal";
 import styles from "./Desktop.module.css";
 import useDesktopStore from "../store/state";
 
@@ -80,7 +81,7 @@ export default function Desktop() {
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        delay: 100,    // 400ms long press (더블클릭 ~300ms보다 충분히 길어 충돌 없음)
+        delay: 80,    // 400ms long press (더블클릭 ~300ms보다 충분히 길어 충돌 없음)
         tolerance: 8,  // 8px 이내 움직임 허용 (손가락/마우스 떨림 방지)
       },
     })
@@ -105,6 +106,10 @@ export default function Desktop() {
   const isInitialLoad = useRef(true);
   // 드래그 중 여부 (마우스 스와이프와 충돌 방지용)
   const activeIdRef = useRef(null);
+  // 폴더 생성 hover 타이머 (500ms)
+  const folderHoverTimerRef = useRef(null);
+  // 현재 hover 중인 타겟 id — 타이머 재시작 방지용
+  const folderHoverTargetRef = useRef(null);
 
   const pages = useDesktopStore((state) => state.pages);
   const currentPage = useDesktopStore((state) => state.currentPage);
@@ -115,6 +120,11 @@ export default function Desktop() {
   const setCurrentPage = useDesktopStore((state) => state.setCurrentPage);
   const setTouchStartX = useDesktopStore((state) => state.setTouchStartX);
   const setActiveId = useDesktopStore((state) => state.setActiveId);
+  const setOpenedFolderId = useDesktopStore((state) => state.setOpenedFolderId);
+  const setHoverTargetId = useDesktopStore((state) => state.setHoverTargetId);
+  const openedFolderId = useDesktopStore((state) => state.openedFolderId);
+  const draggingFromFolderApp = useDesktopStore((state) => state.draggingFromFolderApp);
+  const setDraggingFromFolderApp = useDesktopStore((state) => state.setDraggingFromFolderApp);
 
   currentPageRef.current = currentPage;
   pagesLengthRef.current = pages.length;
@@ -250,12 +260,186 @@ export default function Desktop() {
     }
   };
 
+  // 폴더 hover 타이머 정리 — 단일 지점 (handleDragEnd 최상단에서만 호출)
+  const clearFolderHover = () => {
+    if (folderHoverTimerRef.current) {
+      clearTimeout(folderHoverTimerRef.current);
+      folderHoverTimerRef.current = null;
+    }
+    folderHoverTargetRef.current = null;
+    setHoverTargetId(null);
+  };
+
+  // onDragOver: 앱→앱 500ms hover 시 폴더 자동 생성 (One UI 패턴)
+  const handleDragOver = (event) => {
+    const { active, over } = event;
+    if (!over) {
+      clearFolderHover();
+      return;
+    }
+
+    const overId = String(over.id);
+
+    // 엣지 zone이면 hover 취소
+    if (overId === "page-left" || overId === "page-right") {
+      clearFolderHover();
+      return;
+    }
+
+    // over 아이템 조회 (최신 pages 사용)
+    const currentPages = useDesktopStore.getState().pages;
+    const overPos = findItemPosition(currentPages, overId);
+
+    // over가 빈 슬롯이면 hover 취소
+    if (!overPos || overPos.item.type === "empty") {
+      clearFolderHover();
+      return;
+    }
+
+    // over가 folder 타입인 경우 — 앱→앱과 동일한 500ms 타이머 패턴
+    // 단순 통과와 "폴더에 추가하려는 의도"를 구분하기 위해
+    if (overPos.item.type === "folder") {
+      if (folderHoverTargetRef.current === overId) return;
+      clearFolderHover();
+      folderHoverTargetRef.current = overId;
+      setHoverTargetId(overPos.item.id);
+      folderHoverTimerRef.current = setTimeout(() => {
+        folderHoverTimerRef.current = null;
+        // folderHoverTargetRef.current 유지 — DROP 시 completedHoverTarget 판별용
+        // hoverTargetId 시각 피드백 유지
+      }, 500);
+      return;
+    }
+
+    // active와 over가 동일하면 무시
+    if (String(active.id) === overId) {
+      clearFolderHover();
+      return;
+    }
+
+    // 이미 같은 타겟으로 타이머 진행 중이면 재시작 안 함 (타이머 안정성)
+    if (folderHoverTargetRef.current === overId) return;
+
+    // 새 타겟 — 이전 타이머 정리 후 새 타이머 시작
+    clearFolderHover();
+    folderHoverTargetRef.current = overId;
+    setHoverTargetId(overPos.item.id);
+
+    folderHoverTimerRef.current = setTimeout(() => {
+      // 타이머 완료 마킹 — ref는 유지(의도 완료 상태), 타이머 ref만 null
+      // 실제 폴더 생성은 handleDragEnd에서 DROP 시에만 수행
+      folderHoverTimerRef.current = null;
+      // folderHoverTargetRef.current 유지 — handleDragEnd에서 completedHoverTarget 판별에 사용
+      // hoverTargetId 시각 피드백 유지 — "여기 드롭하면 폴더 생성" 표시
+    }, 500);
+  };
+
   const handleDragStart = (event) => {
-    setActiveId(event.active.id);
+    const { active } = event;
+    setActiveId(active.id);
+
+    // 폴더 모달 앱 드래그 감지 — id 패턴: folder-app-{appId}
+    // 모달은 닫지 않음 — onDragMove에서 포인터가 모달 영역 바깥으로 나갈 때 닫힘
+    if (String(active.id).startsWith("folder-app-")) {
+      const app = active.data.current?.app;
+      if (app && openedFolderId) {
+        setDraggingFromFolderApp({ app, folderId: openedFolderId });
+      }
+    }
+  };
+
+  // onDragMove: 폴더 모달 앱 드래그 중 포인터가 모달 영역 바깥으로 나가면 모달 닫기
+  const handleDragMove = (event) => {
+    // draggingFromFolderApp 상태이고 모달이 아직 열려있는 경우에만 처리
+    const currentOpenedFolderId = useDesktopStore.getState().openedFolderId;
+    const currentDraggingFromFolderApp = useDesktopStore.getState().draggingFromFolderApp;
+    if (!currentDraggingFromFolderApp || !currentOpenedFolderId) return;
+
+    // activatorEvent(최초 포인터 위치) + delta(이동량)으로 현재 포인터 좌표 계산
+    const { activatorEvent, delta } = event;
+    const pointerX = activatorEvent.clientX + delta.x;
+    const pointerY = activatorEvent.clientY + delta.y;
+
+    // data-folder-modal 속성으로 모달 요소 찾기
+    const modalEl = document.querySelector("[data-folder-modal]");
+    if (!modalEl) return;
+
+    const rect = modalEl.getBoundingClientRect();
+    // 포인터가 모달 영역 바깥이면 모달 닫기
+    if (
+      pointerX < rect.left ||
+      pointerX > rect.right ||
+      pointerY < rect.top ||
+      pointerY > rect.bottom
+    ) {
+      setOpenedFolderId(null);
+    }
   };
 
   const handleDragEnd = (event) => {
     const { active, over } = event;
+
+    // 폴더 모달에서 DnD로 앱 꺼내기 처리
+    if (draggingFromFolderApp) {
+      setDraggingFromFolderApp(null);
+      setActiveId(null);
+      clearFolderHover();
+
+      if (over) {
+        const overId = String(over.id);
+        const { app, folderId } = draggingFromFolderApp;
+        const latestPages = useDesktopStore.getState().pages;
+        const nextPages = latestPages.map((p) => [...p]);
+
+        // 폴더에서 앱 제거
+        for (let pi = 0; pi < nextPages.length; pi++) {
+          const folderIdx = nextPages[pi].findIndex(
+            (it) => it.id === folderId && it.type === "folder"
+          );
+          if (folderIdx === -1) continue;
+
+          const folder = nextPages[pi][folderIdx];
+          const newItems = folder.items.filter((it) => it.id !== app.id);
+
+          if (newItems.length === 0) {
+            // 앱 0개 — 빈 슬롯으로 교체
+            nextPages[pi][folderIdx] = {
+              id: `empty-${pi}-${folderIdx}-${Date.now()}`,
+              type: "empty",
+            };
+          } else if (newItems.length === 1) {
+            // 앱 1개 — 폴더 해제, 남은 앱을 폴더 자리에
+            nextPages[pi][folderIdx] = newItems[0];
+          } else {
+            nextPages[pi][folderIdx] = { ...folder, items: newItems };
+          }
+          break;
+        }
+
+        // 드롭 위치에 앱 배치
+        const dropPos = findItemPosition(nextPages, overId);
+        if (dropPos && dropPos.item.type === "empty") {
+          nextPages[dropPos.pageIndex][dropPos.itemIndex] = app;
+        } else {
+          // 빈 슬롯이 아닌 곳에 드롭 → 현재 페이지 첫 번째 빈 슬롯에 배치
+          const curPage = useDesktopStore.getState().currentPage;
+          const emptyIdx = nextPages[curPage].findIndex((it) => it.type === "empty");
+          if (emptyIdx !== -1) nextPages[curPage][emptyIdx] = app;
+        }
+
+        setPages(nextPages);
+      }
+      return;
+    }
+
+    // clearFolderHover 전에 의도 완료 상태 저장
+    // 조건: 타이머 null(500ms 완료됨) + ref에 타겟 있음 = "드롭하면 폴더 생성" 의도 확정
+    const completedHoverTarget =
+      folderHoverTimerRef.current === null && folderHoverTargetRef.current
+        ? folderHoverTargetRef.current
+        : null;
+    // 폴더 hover 타이머 정리 — 단일 지점
+    clearFolderHover();
     setActiveId(null);
     if (!over) return;
 
@@ -320,8 +504,44 @@ export default function Desktop() {
       return;
     }
 
-    // B. 앱 → 앱 위로 드롭 (arrayMove 삽입 정렬 또는 페이지 간 교환)
-    if (fromPage === toPage) {
+    // B. 앱 → 폴더 위로 드롭 (500ms hover 완료 시에만 폴더에 앱 추가)
+    if (toItem.type === 'folder') {
+      // 500ms 미충족 — 단순 통과 드롭 → 무시 (앱 원위치)
+      if (!completedHoverTarget || completedHoverTarget !== overId) return;
+      // active 아이템을 folder.items 맨 뒤에 추가
+      nextPages[toPage][toIndex] = {
+        ...toItem,
+        items: [...toItem.items, fromPos.item],
+      };
+      // active 원래 위치를 빈 슬롯으로 교체
+      nextPages[fromPage][fromIndex] = {
+        id: `empty-${fromPage}-${fromIndex}-${Date.now()}`,
+        type: 'empty',
+      };
+      setPages(nextPages);
+      return;
+    }
+
+    // C. 앱 → 앱 위로 드롭
+    // - completedHoverTarget === overId: 500ms hover 완료 후 DROP → 폴더 생성
+    // - 그 외: arrayMove 삽입 정렬 또는 페이지 간 교환
+    if (completedHoverTarget && completedHoverTarget === overId) {
+      // 폴더 생성 — DROP 시에만 실행
+      const newFolderId = `folder-${crypto.randomUUID().split("-")[0]}`;
+      const newFolder = {
+        id: newFolderId,
+        type: "folder",
+        name: "새 폴더",
+        items: [fromPos.item, toItem],
+      };
+      // over 위치에 새 폴더 배치
+      nextPages[toPage][toIndex] = newFolder;
+      // active 원래 위치를 빈 슬롯으로 교체
+      nextPages[fromPage][fromIndex] = {
+        id: `empty-${fromPage}-${fromIndex}-${Date.now()}`,
+        type: "empty",
+      };
+    } else if (fromPage === toPage) {
       nextPages[fromPage] = arrayMove(nextPages[fromPage], fromIndex, toIndex);
     } else {
       const temp = nextPages[fromPage][fromIndex];
@@ -370,6 +590,8 @@ export default function Desktop() {
           sensors={sensors}
           collisionDetection={createEdgeCollision(wrapperRef)}
           onDragStart={handleDragStart}
+          onDragMove={handleDragMove}
+          onDragOver={handleDragOver}
           onDragEnd={handleDragEnd}
         >
           <div className={styles.desktopViewport}>
@@ -389,6 +611,16 @@ export default function Desktop() {
                       {pageItems.map((item) => {
                         if (item.type === 'empty') {
                           return <EmptySlot key={item.id} id={item.id} />;
+                        }
+
+                        if (item.type === 'folder') {
+                          return (
+                            <FolderIcon
+                              key={item.id}
+                              folder={item}
+                              openFolder={() => setOpenedFolderId(item.id)}
+                            />
+                          );
                         }
 
                         return (
@@ -416,15 +648,30 @@ export default function Desktop() {
           )}
 
           <DragOverlay dropAnimation={dropAnimationConfig}>
-            {activeItem && activeItem.type !== 'empty' ? (
+            {draggingFromFolderApp ? (
+              // 폴더 모달 앱 꺼내기 — 모달이 닫히고 DragOverlay가 앱을 이어받음
               <div style={{
                 transform: 'scale(1.15)',
                 filter: 'drop-shadow(0 8px 20px rgba(0, 0, 0, 0.5))',
               }}>
-                <AppIconOverlay app={activeItem} />
+                <AppIconOverlay app={draggingFromFolderApp.app} />
+              </div>
+            ) : activeItem && activeItem.type !== 'empty' ? (
+              <div style={{
+                transform: 'scale(1.15)',
+                filter: 'drop-shadow(0 8px 20px rgba(0, 0, 0, 0.5))',
+              }}>
+                {activeItem.type === 'folder' ? (
+                  <FolderIconOverlay folder={activeItem} />
+                ) : (
+                  <AppIconOverlay app={activeItem} />
+                )}
               </div>
             ) : null}
           </DragOverlay>
+
+          {/* 폴더 열기 모달 — DndContext 안에서 렌더링 (useDraggable DnD 핸드오프를 위해) */}
+          <FolderModal />
         </DndContext>
       </div>
 

--- a/src/components/Desktop/store/state.js
+++ b/src/components/Desktop/store/state.js
@@ -5,11 +5,17 @@ const useDesktopStore = create((set) => ({
   currentPage: 0,
   touchStartX: null,
   activeId: null,
+  openedFolderId: null,   // 현재 열린 폴더 id (null = 닫힘)
+  hoverTargetId: null,    // 폴더 생성 hover 중인 대상 app id (One UI 시각 피드백용)
+  draggingFromFolderApp: null,  // { app: AppItem, folderId: string } | null — 폴더 모달에서 DnD로 꺼내는 중
 
   setPages: (pages) => set({ pages }),
   setCurrentPage: (index) => set({ currentPage: index }),
   setTouchStartX: (x) => set({ touchStartX: x }),
   setActiveId: (id) => set({ activeId: id }),
+  setOpenedFolderId: (id) => set({ openedFolderId: id }),
+  setHoverTargetId: (id) => set({ hoverTargetId: id }),
+  setDraggingFromFolderApp: (val) => set({ draggingFromFolderApp: val }),
 }));
 
 export default useDesktopStore;

--- a/src/components/FolderIcon/main/FolderIcon.js
+++ b/src/components/FolderIcon/main/FolderIcon.js
@@ -3,7 +3,8 @@ import styles from "./FolderIcon.module.css";
 import useDesktopStore from "../../Desktop/store/state";
 
 // 앱 아이콘이 없는 경우를 위해 간단한 플레이스홀더
-function getAppIcon(app) {
+// named export — FolderModal에서도 import해서 사용
+export function getAppIcon(app) {
   if (app.icon && typeof app.icon === "string" && app.icon.length > 0) {
     return app.icon;
   }
@@ -37,6 +38,9 @@ export default function AppIcon({ app, openApp }) {
 
   // activeId: smooth reorder transition 조건부 적용용
   const activeId = useDesktopStore((state) => state.activeId);
+  // hoverTargetId: One UI 시각 피드백용 — 폴더 생성 hover 중인 대상 아이콘 강조
+  const hoverTargetId = useDesktopStore((state) => state.hoverTargetId);
+  const isHoverTarget = hoverTargetId === app.id;
 
   const style = {
     transform: transform
@@ -58,12 +62,73 @@ export default function AppIcon({ app, openApp }) {
       {...listeners}
       style={style}
       onDoubleClick={openApp}
-      className={styles.appIcon}
+      className={`${styles.appIcon}${isHoverTarget ? ` ${styles.folderHoverTarget}` : ""}`}
     >
       <div className={styles.iconWrapper}>
         <img src={getAppIcon(app)} alt={app.name} />
       </div>
       <span className={styles.label}>{app.name}</span>
+    </div>
+  );
+}
+
+/** 폴더 아이콘 (정렬 가능한 폴더) */
+export function FolderIcon({ folder, openFolder }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: folder.id, animateLayoutChanges });
+
+  const activeId = useDesktopStore((state) => state.activeId);
+  // hoverTargetId: 앱→폴더 500ms hover 시각 피드백용
+  const hoverTargetId = useDesktopStore((state) => state.hoverTargetId);
+  const isHoverTarget = hoverTargetId === folder.id;
+
+  const style = {
+    transform: transform
+      ? `translate3d(${Math.round(transform.x)}px, ${Math.round(transform.y)}px, 0)`
+      : undefined,
+    transition: activeId ? transition : undefined,
+    opacity: isDragging ? 0 : 1,
+    cursor: "grab",
+  };
+
+  // 최대 9개 썸네일 (3×3 그리드)
+  const thumbItems = (folder.items || []).slice(0, 9);
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-sortable="true"
+      {...attributes}
+      {...listeners}
+      style={style}
+      onDoubleClick={openFolder}
+      className={`${styles.folderIcon}${isHoverTarget ? ` ${styles.folderHoverTarget}` : ""}`}
+    >
+      <div className={styles.thumbGrid}>
+        {thumbItems.map((app) => (
+          <div key={app.id} className={styles.thumbItem}>
+            <img src={getAppIcon(app)} alt={app.name} />
+          </div>
+        ))}
+      </div>
+      <span className={styles.label}>{folder.name}</span>
+    </div>
+  );
+}
+
+/** 폴더 드래그 오버레이용 */
+export function FolderIconOverlay({ folder }) {
+  const thumbItems = (folder.items || []).slice(0, 9);
+  return (
+    <div className={styles.folderIcon} style={{ cursor: "grabbing" }}>
+      <div className={styles.thumbGrid}>
+        {thumbItems.map((app) => (
+          <div key={app.id} className={styles.thumbItem}>
+            <img src={getAppIcon(app)} alt={app.name} />
+          </div>
+        ))}
+      </div>
+      <span className={styles.label}>{folder.name}</span>
     </div>
   );
 }

--- a/src/components/FolderIcon/main/FolderIcon.module.css
+++ b/src/components/FolderIcon/main/FolderIcon.module.css
@@ -38,3 +38,61 @@
   word-break: break-word;
 }
 
+/* ─── 폴더 아이콘 ─── */
+
+/* 폴더 컨테이너 — .appIcon과 동일 크기, 반투명 배경 */
+.folderIcon {
+  user-select: none;
+  width: 80px;
+  height: 80px;
+  background-color: rgba(180, 180, 200, 0.35);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: 10px;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease;
+}
+
+.folderIcon:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* 3x3 썸네일 그리드 */
+.thumbGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+  width: 52px;
+  height: 52px;
+  padding: 4px;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+/* 개별 썸네일 */
+.thumbItem {
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  overflow: hidden;
+  background-color: #333;
+}
+
+.thumbItem img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* ─── One UI 시각 피드백 ─── */
+
+/* 앱→앱 hover 중인 대상 아이콘 강조 (단계 2: hover 진행 중) */
+.folderHoverTarget {
+  transform: scale(0.9) !important;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.6) !important;
+  border-radius: 16px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease !important;
+}

--- a/src/components/FolderModal/main/FolderModal.js
+++ b/src/components/FolderModal/main/FolderModal.js
@@ -1,0 +1,72 @@
+import React from "react";
+import { useDraggable } from "@dnd-kit/core";
+import useDesktopStore from "../../Desktop/store/state";
+import { getAppIcon } from "../../FolderIcon/main/FolderIcon";
+import styles from "./FolderModal.module.css";
+
+/**
+ * 폴더 모달 내 앱 아이템 — useDraggable 적용
+ * id 패턴: folder-app-{app.id} — Desktop.js onDragStart에서 감지
+ * 드래그 시작 시 모달이 즉시 닫히고 DragOverlay가 앱 아이콘을 이어받음
+ */
+function FolderAppItem({ app }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `folder-app-${app.id}`,
+    data: { app },  // onDragStart에서 active.data.current.app으로 접근
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className={styles.appItem}
+      style={{ opacity: isDragging ? 0 : 1 }}
+      onDoubleClick={() => window.electronAPI?.runApp?.(app.path)}
+    >
+      <div className={styles.iconWrapper}>
+        <img src={getAppIcon(app)} alt={app.name} />
+      </div>
+      <span className={styles.label}>{app.name}</span>
+    </div>
+  );
+}
+
+/**
+ * 폴더 열기 모달
+ * - openedFolderId가 있으면 해당 폴더를 pages에서 탐색하여 표시
+ * - 배경 클릭 시 닫힘 (e.stopPropagation으로 모달 내부 클릭은 닫힘 방지)
+ * - 앱 홀딩 드래그 시 모달 닫히고 DnD로 앱 꺼내기 가능
+ */
+export default function FolderModal() {
+  const openedFolderId = useDesktopStore((state) => state.openedFolderId);
+  const setOpenedFolderId = useDesktopStore((state) => state.setOpenedFolderId);
+  const pages = useDesktopStore((state) => state.pages);
+
+  if (!openedFolderId) return null;
+
+  // 모든 페이지에서 해당 폴더 탐색
+  let folder = null;
+  for (const page of pages) {
+    const found = page.find((it) => it.id === openedFolderId && it.type === "folder");
+    if (found) {
+      folder = found;
+      break;
+    }
+  }
+
+  if (!folder) return null;
+
+  return (
+    <div className={styles.backdrop} onClick={() => setOpenedFolderId(null)}>
+      <div className={styles.modal} data-folder-modal onClick={(e) => e.stopPropagation()}>
+        <h2 className={styles.title}>{folder.name}</h2>
+        <div className={styles.grid}>
+          {(folder.items || []).map((app) => (
+            <FolderAppItem key={app.id} app={app} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FolderModal/main/FolderModal.module.css
+++ b/src/components/FolderModal/main/FolderModal.module.css
@@ -1,0 +1,62 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background-color: rgba(40, 40, 60, 0.92);
+  border-radius: 20px;
+  padding: 24px;
+  min-width: 320px;
+  max-width: 500px;
+  backdrop-filter: blur(20px);
+}
+
+.title {
+  color: #fff;
+  font-size: 18px;
+  text-align: center;
+  margin: 0 0 16px 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 80px);
+  gap: 12px;
+  justify-content: center;
+}
+
+.appItem {
+  width: 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: grab;
+}
+
+.iconWrapper {
+  width: 52px;
+  height: 52px;
+  border-radius: 10px;
+  overflow: hidden;
+  background-color: #222;
+}
+
+.iconWrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.label {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #fff;
+  text-align: center;
+  word-break: break-word;
+}


### PR DESCRIPTION
## Summary
- 앱→앱 500ms hover 후 DROP 시 폴더 생성 (completedHoverTarget 패턴)
- 앱→폴더 500ms hover 후 DROP 시 폴더에 앱 추가
- 폴더/앱 hover 시 One UI 시각 피드백 (hoverTargetId)
- 폴더 아이콘 상단 여백 개선 (padding-top, flex-start)
- 폴더 모달: useDraggable DnD로 앱 꺼내기 (모달 영역 이탈 시 모달 닫힘)
- draggingFromFolderApp Zustand 상태 추가

## Test plan
- [ ] 앱→앱 500ms hover 후 드롭 → 폴더 생성
- [ ] 앱→앱 500ms 미만 hover 드롭 → arrayMove 정렬
- [ ] 앱→폴더 500ms hover 후 드롭 → 폴더에 앱 추가
- [ ] 앱→폴더 단순 통과 드롭 → 무시
- [ ] 폴더 더블클릭 → 모달 열기
- [ ] 폴더 모달에서 앱 홀딩 → 드래그 시작, 모달 유지
- [ ] 드래그하며 모달 영역 이탈 → 모달 닫힘, DragOverlay 이어받음
- [ ] 빈 슬롯에 드롭 → 앱 배치, 폴더에서 제거
- [ ] 앱 1개 남은 폴더에서 꺼내기 → 폴더 해제
- [ ] 드롭 취소(ESC) → 앱 폴더에 그대로 유지

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)